### PR TITLE
migrate to AlmaLinux 8 from CentOS 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM almalinux:8
 ENV HOME /
 RUN yum update -y
 RUN yum install -y rpm-build redhat-rpm-config rpmdevtools


### PR DESCRIPTION
CentOS 7 ends its life. Let's migrate to AlmaLinux 8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to use `almalinux:8` as the base image instead of `centos:7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->