### PR TITLE
Revert "bump sqldef v2.4.3"

### DIFF
--- a/rpmbuild/SPECS/sqldef.spec
+++ b/rpmbuild/SPECS/sqldef.spec
@@ -10,7 +10,7 @@
 
 Summary: Idempotent MySQL/PostgreSQL schema management by SQL
 Name: sqldef
-Version: 2.4.3
+Version: 2.4.2
 Release: 1
 URL: https://github.com/sqldef/sqldef
 Source0: https://github.com/sqldef/sqldef/releases/download/v%{version}/mssqldef_linux_%{goarch}.tar.gz
@@ -51,9 +51,6 @@ rm -rf %{buildroot}
 %{_bindir}/sqlite3def
 
 %changelog
-* Mon Sep 15 2025 ICHINOSE Shogo <shogo82148@gmail.com> - 2.4.3-1
-- bump v2.4.3
-
 * Sun Sep 14 2025 ICHINOSE Shogo <shogo82148@gmail.com> - 2.4.2-1
 - bump v2.4.2
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ set -exu
 ROOT=$(cd "$(dirname "$0")/../" && pwd)
 PLATFORM=$1
 
-VERSION=2.4.3
+VERSION=2.4.2
 IMAGE_NAME=sqldef-package-$PLATFORM
 TARGZ_FILE=sqldef.tar.gz
 


### PR DESCRIPTION
Reverts shogo82148/sqldef-rpm#304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Rolled back the package version from 2.4.3 to 2.4.2 to align with the current release. Removed the 2.4.3 changelog entry. Installations will now display version 2.4.2.

* **Chores**
  * Updated build and packaging metadata to reflect version 2.4.2. No changes to features, behavior, or performance. Users should not experience any differences aside from the reported version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->