### PR TITLE
drop CentOS support

### DIFF
--- a/scripts/upload.pl
+++ b/scripts/upload.pl
@@ -43,8 +43,6 @@ sub upload {
 
 upload "amazonlinux/2";
 upload "amazonlinux/2023";
-upload "centos/7";
-upload "centos/8";
 upload "almalinux/8";
 upload "almalinux/9";
 upload "rockylinux/8";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed RPM package support for CentOS 7 and CentOS 8. Packages are now available exclusively for Amazon Linux 2, Amazon Linux 2023, AlmaLinux 8/9, and Rocky Linux 8/9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->