### PR TITLE
drop Amazon Linux 2 support

### DIFF
--- a/scripts/upload.pl
+++ b/scripts/upload.pl
@@ -41,7 +41,6 @@ sub upload {
     }
 }
 
-upload "amazonlinux/2";
 upload "amazonlinux/2023";
 upload "centos/7";
 upload "centos/8";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Discontinued automated package uploads for Amazon Linux 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->